### PR TITLE
add google analytics data

### DIFF
--- a/lib/gtag.js
+++ b/lib/gtag.js
@@ -1,0 +1,18 @@
+// https://github.com/vercel/next.js/blob/506116c7d03aa7ca1acae68579b64894eb598ee1/examples/with-google-analytics/lib/gtag.js
+export const GA_TRACKING_ID = 'UA-179266479-1'
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/pages
+export const pageview = (url) => {
+  window.gtag('config', GA_TRACKING_ID, {
+    page_path: url,
+  })
+}
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/events
+export const event = ({ action, category, label, value }) => {
+  window.gtag('event', action, {
+    event_category: category,
+    event_label: label,
+    value,
+  })
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,9 +1,20 @@
-import React from 'react'
+import React, { useEffect } from 'react'
+import Router from 'next/router'
+import * as gtag from '../lib/gtag'
 import '../styles/globals.css'
 import '../setup/setTheme'
 
 // eslint-disable-next-line react/prop-types
-function MyApp({ Component, pageProps }) {
+const MyApp = ({ Component, pageProps }) => {
+  useEffect(() => {
+    const handleRouteChange = (url) => {
+      gtag.pageview(url)
+    }
+    Router.events.on('routeChangeComplete', handleRouteChange)
+    return () => {
+      Router.events.off('routeChangeComplete', handleRouteChange)
+    }
+  }, [])
   // eslint-disable-next-line react/jsx-props-no-spreading
   return <Component {...pageProps} />
 }

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import Document, { Head, Main, NextScript } from 'next/document'
+
+import { GA_TRACKING_ID } from '../lib/gtag'
+
+export default class MyDocument extends Document {
+  render() {
+    return (
+      <html lang="en-US">
+        <Head>
+          {/* Global Site Tag (gtag.js) - Google Analytics */}
+          <script
+            async
+            src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
+          />
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '${GA_TRACKING_ID}', {
+              page_path: window.location.pathname,
+            });
+          `,
+            }}
+          />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </html>
+    )
+  }
+}


### PR DESCRIPTION
Resolves #30

Creates tracking links per example:
https://github.com/vercel/next.js/tree/506116c7d03aa7ca1acae68579b64894eb598ee1/examples/with-google-analytics